### PR TITLE
feat: publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Verify tag matches package version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "Tag $TAG doesn't match package version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Version validation successful: $TAG"
+
+  build-and-publish:
+    needs: validate-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.5
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Publish package
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+          pnpm publish --no-git-checks --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        run: gh release create ${GITHUB_REF#refs/tags/} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,23 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  validate-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Verify tag matches package version
-        run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$TAG" != "$PKG_VERSION" ]; then
-            echo "Tag $TAG doesn't match package version $PKG_VERSION"
-            exit 1
-          fi
-          echo "Version validation successful: $TAG"
-
   build-and-publish:
-    needs: validate-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,8 +16,16 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 22
+      - name: Verify tag matches package version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "Tag $TAG doesn't match package version $PKG_VERSION"
+            exit 1
+          fi
+          echo "Version validation successful: $TAG"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/README.md
+++ b/README.md
@@ -169,6 +169,33 @@ pnpm test
 pnpm test:watch
 ```
 
+### Releasing
+
+This package follows semantic versioning. To release a new version:
+
+1. Choose the appropriate release type based on your changes:
+   ```bash
+   # For bug fixes and minor changes (0.0.x)
+   pnpm release:patch
+
+   # For new features - backward compatible (0.x.0)
+   pnpm release:minor
+
+   # For breaking changes (x.0.0)
+   pnpm release:major
+   ```
+
+2. Push the new tag to GitHub:
+   ```bash
+   git push --follow-tags
+   ```
+
+3. The GitHub Actions workflow will automatically:
+   - Validate that the tag version matches the package.json version
+   - Run tests and build the package
+   - Publish to npm (requires npm authentication)
+   - Create a GitHub Release for the tag
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "clean": "rm -rf dist",
     "prepare": "npm run build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "release:patch": "npm version patch -m \"chore(release): %s\"",
+    "release:minor": "npm version minor -m \"chore(release): %s\"",
+    "release:major": "npm version major -m \"chore(release): %s\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Add automated npm package publishing workflow

### TL;DR

Add GitHub Actions workflow to automate package publishing and release creation when a new version tag is pushed.

**Tested using --dry-run flag** 

<img width="726" alt="Screenshot 2025-03-18 at 2 01 07 PM" src="https://github.com/user-attachments/assets/20ff479b-8b1b-411b-80c9-e925300e922b" />


### What changed?

- Added `.github/workflows/publish.yml` to handle automated package publishing
- Added release scripts to `package.json` for versioning (`release:patch`, `release:minor`, `release:major`)
- Updated README with detailed release instructions

### How to test?

1. Create a new version using one of the release commands:
   ```bash
   pnpm release:patch
   ```
2. Push the tag:
   ```bash
   git push --follow-tags
   ```
3. Verify the GitHub Actions workflow runs successfully
4. Confirm the package is published to npm and a GitHub Release is created

### Why make this change?

Streamlines the release process by automating the tedious steps of publishing to npm and creating GitHub releases. This ensures consistent releases and reduces manual errors during the publishing process.