### PR TITLE
feat: support cjs too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,22 @@
 {
   "name": "@replit/graphql-codegen-persisted-queries",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "GraphQL plugin to generate persisted query manifests",
-  "main": "dist/index.mjs",
+  "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
   "files": [
     "dist",
     "README.md"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,10 +4,15 @@ export default defineConfig({
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
-  format: ['esm'],
+  format: ['esm', 'cjs'],
   sourcemap: true,
   minify: true,
   target: 'esnext',
   outDir: 'dist',
   treeshake: true,
+  outExtension({ format }) {
+    return {
+      js: format === 'esm' ? '.mjs' : '.js',
+    };
+  },
 });


### PR DESCRIPTION
### TL;DR

Added CommonJS support to the package alongside existing ESM format.


 ( insert old man yelling at js ecosystem ) when testing locally I was simply doing `pnpm add <path>` and it used to work with the repl-it-web codegen but after publishing and using the published version, had interop issues 

This time, built, packaged as tar and installed locally with the tar to test it 


![Screenshot 2025-03-18 at 2.43.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/l8nD2yob02SPYlqlUGqW/cea85fd9-1c4e-4748-8c1b-03917ab4f3e3.png)

![Screenshot 2025-03-18 at 2.43.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/l8nD2yob02SPYlqlUGqW/ad222d7c-8b35-4884-9999-ba17079062bf.png)

![Screenshot 2025-03-18 at 2.47.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/l8nD2yob02SPYlqlUGqW/5e60ae0c-6181-4d80-9e14-f05d66a5e780.png)



### What changed?

- Changed main entry point from `dist/index.mjs` to `dist/index.js`
- Updated types path from `dist/index.d.mts` to `dist/index.d.ts`
- Added proper `exports` field in package.json to support both ESM and CommonJS imports
- Modified tsup configuration to build both ESM and CommonJS formats
- Added output extension configuration to ensure proper file extensions (.mjs for ESM, .js for CJS)
